### PR TITLE
Document use of action outputs in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,21 +4,21 @@ Creates a new tag using the format `Y.M.D` (using [daily-version](https://github
 
 Ideally used on schedule, but you could also change the suggested condition to only make it run on `master`.
 
-# Usage
+## Usage
+
+It expects `git` to be configured to push to the same repo, perhaps via [fregante/setup-git-token](https://github.com/fregante/setup-git-token)
 
 See [action.yml](action.yml)
-
-Basic:
 
 ```yaml
   Version:
     steps:
     - uses: actions/checkout@v2
-    - uses: fregante/setup-git-token@v1 # This will allow saving the generated tag
+    - uses: fregante/setup-git-token@v1 # Allows pushing the generated tag to the repo
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
     - name: Create tag if necessary
-      if: github.event_name == 'schedule' # This ensures it only runs on a schedule
+      if: github.event_name == 'schedule' # Ensures it only runs on a schedule
       uses: fregante/daily-version-action@v1
 ```
 
@@ -37,3 +37,14 @@ Regradless of creating a new version, the most recent version can be accessed us
     needs: Version
     run: echo "Current version: ${{needs.Version.outputs.version}}"
 ```
+
+## Inputs
+
+None
+
+## Outputs
+
+- `created` - If this output exists, this action created a new tag
+- `version` - The latest tag, whether it already existed or if it was just created
+
+Outputs can be [used across jobs](https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjobs_idoutputs) as well.

--- a/README.md
+++ b/README.md
@@ -22,20 +22,12 @@ See [action.yml](action.yml)
       uses: fregante/daily-version-action@v1
 ```
 
-To check if any new version has been created in other jobs, use [`job.outputs`](https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjobs_idoutputs) object to see if `created` property is set. This property would not be set if any new versions are created.
+You can use the `created` output of this action to test whether a new version has been created, even [across jobs](https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjobs_idoutputs):
 
 ```yaml
   Build:
     needs: Version
     if: github.event_name == 'push' || needs.Version.outputs.created
-```
-
-Regradless of creating a new version, the most recent version can be accessed using the `job.outputs.version` property, after this action is run.
-
-``` yaml
-  Cleanup:
-    needs: Version
-    run: echo "Current version: ${{needs.Version.outputs.version}}"
 ```
 
 ## Inputs

--- a/README.md
+++ b/README.md
@@ -25,9 +25,12 @@ See [action.yml](action.yml)
 You can use the `created` output of this action to test whether a new version has been created, even [across jobs](https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjobs_idoutputs):
 
 ```yaml
-  Build:
-    needs: Version
-    if: github.event_name == 'push' || needs.Version.outputs.created
+    - name: 'Create tag if necessary'
+      id: version
+      uses: fregante/daily-version-action@v1
+    - name: 'Created?'
+      if: steps.version.outputs.created
+      runs: echo 'Created!' ${{ steps.version.outputs.version }}
 ```
 
 ## Inputs

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Ideally used on schedule, but you could also change the suggested condition to o
 
 ## Usage
 
-It expects `git` to be configured to push to the same repo, perhaps via [fregante/setup-git-token](https://github.com/fregante/setup-git-token)
+It expects `git` to be configured to push to the same repo, perhaps via [fregante/setup-git-token](https://github.com/fregante/setup-git-token).
 
 See [action.yml](action.yml)
 
@@ -40,11 +40,11 @@ Regradless of creating a new version, the most recent version can be accessed us
 
 ## Inputs
 
-None
+None.
 
 ## Outputs
 
-- `created` - If this output exists, this action created a new tag
-- `version` - The latest tag, whether it already existed or if it was just created
+- `created` - If this output exists, this action created a new tag.
+- `version` - The latest tag, whether it already existed or if it was just created.
 
 Outputs can be [used across jobs](https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjobs_idoutputs) as well.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ See [action.yml](action.yml)
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
     - name: Create tag if necessary
-      if: github.event_name == 'schedule' # Ensures it only runs on a schedule
       uses: fregante/daily-version-action@v1
 ```
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Creates a new tag using the format `Y.M.D` (using [daily-version](https://github.com/fregante/daily-version)), but only if `HEAD` isn’t already tagged.
 
-Ideally used on schedule, but you could also change the suggested condition to only make it run on `master`
+Ideally used on schedule, but you could also change the suggested condition to only make it run on `master`.
 
 # Usage
 
@@ -11,6 +11,7 @@ See [action.yml](action.yml)
 Basic:
 
 ```yaml
+  Version:
     steps:
     - uses: actions/checkout@v2
     - uses: fregante/setup-git-token@v1 # This will allow saving the generated tag
@@ -19,4 +20,20 @@ Basic:
     - name: Create tag if necessary
       if: github.event_name == 'schedule' # This ensures it only runs on a schedule
       uses: fregante/daily-version-action@v1
+```
+
+To check if any new version has been created in other jobs, use [`job.outputs`](https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjobs_idoutputs) object to see if `created` property is set. This property would not be set if any new versions are created.
+
+```yaml
+  Build:
+    needs: Version
+    if: github.event_name == 'push' || needs.Version.outputs.created
+```
+
+Regradless of creating a new version, the most recent version can be accessed using the `job.outputs.version` property, after this action is run.
+
+``` yaml
+  Cleanup:
+    needs: Version
+    run: echo "Current version: ${{needs.Version.outputs.version}}"
 ```


### PR DESCRIPTION
Most people do not know that you could transfer data between actions. This change documents how outputs generated by this action could be used in other jobs/steps.